### PR TITLE
Fix OpenLayers SRI hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Indoor Biking Web App</title>
-    <link
+      <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/ol@9.2.4/ol.css"
-      integrity="sha256-VfAyUe2uDkE1PH5rrMFgGsY96XnZpNgRsibzXsT4C3Y="
+      integrity="sha256-tGpYjsT520+CTqFasreL2dHfsXFyp4XGniP6iVPbQ38="
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="styles.css" />
@@ -120,7 +120,7 @@
 
     <script
       src="https://cdn.jsdelivr.net/npm/ol@9.2.4/dist/ol.js"
-      integrity="sha256-euI1y9qFPrn8iDPuCDeA5c39P8qXr5CV7omY6S+2bW0="
+      integrity="sha256-EYwynPWNQRIqQJf5qKvl9StW64DPx9+DxczvjXuXb74="
       crossorigin="anonymous"
     ></script>
     <script type="module" src="app.js"></script>


### PR DESCRIPTION
### Motivation
- Browser blocked the OpenLayers CDN files due to SRI (Subresource Integrity) mismatches, preventing the library from loading.
- Because `ol` was not available, `app.js` failed at runtime with `ol is not defined` and the rest of the app initialization (including Web Bluetooth handlers) did not run.
- Update the SRI hashes so the CDN assets load and the map and event handlers initialized in `app.js` can run.

### Description
- Updated the `integrity` attributes for the OpenLayers CDN files in `index.html` by replacing the hashes for `ol.css` and `ol.js` with the correct SHA-256 values.
- Change is confined to `index.html` and only touches the two SRI attributes for the CDN links.
- Restores loading of the `ol` global so the map construction and subsequent code in `app.js` can execute normally.

### Testing
- No automated tests were run for this static change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965580b04788324bf02d0b3988ce76a)