### PR TITLE
Add Bluetooth diagnostics panel (multi-device raw characteristic viewer)

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,26 @@
         </div>
         <div class="event-log" id="event-log"></div>
       </section>
+
+      <section class="card" aria-labelledby="diagnostics-heading">
+        <h2 id="diagnostics-heading">Bluetooth Diagnostics</h2>
+        <p class="helper">
+          Connect multiple devices, stream button presses, and read raw characteristic data.
+        </p>
+        <div class="control-row">
+          <label for="diagnostic-services">Optional service UUIDs</label>
+          <input
+            id="diagnostic-services"
+            type="text"
+            placeholder="fitness_machine, 0000180f-0000-1000-8000-00805f9b34fb"
+          />
+        </div>
+        <div class="button-row">
+          <button id="connect-diagnostic">Scan &amp; connect device</button>
+          <button id="disconnect-diagnostic" disabled>Disconnect all</button>
+        </div>
+        <div id="diagnostic-devices" class="diagnostic-devices"></div>
+      </section>
     </main>
 
     <script

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,14 @@ button:disabled {
   gap: 0.75rem;
 }
 
+.control-row input[type="text"] {
+  min-width: 260px;
+  flex: 1;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+}
+
 .control-row input[type="number"] {
   width: 80px;
   padding: 0.3rem 0.5rem;
@@ -139,9 +147,104 @@ button:disabled {
   overflow-y: auto;
 }
 
+.helper {
+  margin: 0;
+  color: #52607a;
+  font-size: 0.9rem;
+}
+
 .gear-row {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.diagnostic-devices {
+  display: grid;
+  gap: 1rem;
+}
+
+.diagnostic-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+  background: #f8fafc;
+}
+
+.diagnostic-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.diagnostic-meta {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #3b455c;
+}
+
+.diagnostic-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.diagnostic-actions button {
+  background: #0ea5e9;
+}
+
+.diagnostic-actions button.secondary {
+  background: #475569;
+}
+
+.diagnostic-actions button.warn {
+  background: #dc2626;
+}
+
+.data-grid {
+  display: grid;
+  gap: 0.5rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.data-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.data-card strong {
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.data-card span {
+  font-family: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8rem;
+  word-break: break-word;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.button-pill {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
+  text-align: center;
 }


### PR DESCRIPTION
### Motivation
- The app needs a diagnostic surface to pair multiple Bluetooth devices and inspect button presses and raw characteristic data to debug issues like duplicate Zwift controllers, missing button events, and absent power readings.
- A lightweight, in-browser tool helps surface notify/read data from arbitrary services and characteristics for faster debugging and validation.

### Description
- Add a new `Bluetooth Diagnostics` panel to `index.html` with inputs to provide optional service UUIDs and controls to scan/connect and disconnect devices (`index.html`).
- Implement diagnostics logic in `app.js` to discover services, read characteristics, start notifications, format raw bytes and ASCII, display characteristic data, and tally button/notify events per device; multiple devices are tracked via a `diagnostics` map (`app.js`).
- Add UI styles for diagnostic cards, data grids, button pills, and helper text to `styles.css` and wire up the connect/disconnect handlers to the new buttons (`styles.css`, `app.js`).
- Wire the diagnostics cards to support re-reading characteristics, refreshing displayed data, and disconnecting individual devices (`app.js`).

### Testing
- Started a local development server with `python -m http.server 8000` and verified the site served successfully. 
- Ran a Playwright smoke test (Firefox) to load the page and capture a screenshot of the diagnostics panel, which completed and produced an artifact. 
- No unit tests were added or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965608b898c8324b3f1ab2847f4d996)