### PR TITLE
Add Web Bluetooth support notice and guard connection flows

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const connectTrainerBtn = document.getElementById("connect-trainer");
 const disconnectTrainerBtn = document.getElementById("disconnect-trainer");
 const connectZwiftBtn = document.getElementById("connect-zwift");
 const disconnectZwiftBtn = document.getElementById("disconnect-zwift");
+const bluetoothSupportEl = document.getElementById("bluetooth-support");
 const zwiftStatus = document.getElementById("zwift-status");
 const zwiftCharStatus = document.getElementById("zwift-char");
 const powerEl = document.getElementById("power");
@@ -18,6 +19,10 @@ const eventLog = document.getElementById("event-log");
 const gearDisplay = document.getElementById("gear-display");
 const loopStatus = document.getElementById("loop-status");
 const reloadRouteBtn = document.getElementById("reload-route");
+const connectDiagnosticBtn = document.getElementById("connect-diagnostic");
+const disconnectDiagnosticBtn = document.getElementById("disconnect-diagnostic");
+const diagnosticDevicesEl = document.getElementById("diagnostic-devices");
+const diagnosticServicesInput = document.getElementById("diagnostic-services");
 
 const FTMS_SERVICE = "00001826-0000-1000-8000-00805f9b34fb";
 const INDOOR_BIKE_DATA = "00002ad2-0000-1000-8000-00805f9b34fb";
@@ -45,6 +50,8 @@ let currentDistance = 0;
 let lastLoopAt = null;
 let autoLoopTimer = null;
 let lastResistanceSet = null;
+
+const diagnostics = new Map();
 
 const map = new ol.Map({
   target: "map",
@@ -84,6 +91,40 @@ function logEvent(message) {
   const timestamp = new Date().toLocaleTimeString();
   entry.textContent = `[${timestamp}] ${message}`;
   eventLog.prepend(entry);
+}
+
+function setBluetoothSupportStatus() {
+  if (!bluetoothSupportEl) {
+    return;
+  }
+  const hasWebBluetooth = !!navigator.bluetooth;
+  if (!hasWebBluetooth) {
+    bluetoothSupportEl.dataset.support = "unsupported";
+    bluetoothSupportEl.textContent =
+      "Web Bluetooth is unavailable in this browser (iOS Safari/Chrome do not support it).";
+    return;
+  }
+  bluetoothSupportEl.dataset.support = "supported";
+  bluetoothSupportEl.textContent = "Web Bluetooth is supported in this browser.";
+}
+
+function formatBytes(value) {
+  if (!value) {
+    return "--";
+  }
+  return Array.from(value)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join(" ");
+}
+
+function formatAscii(value) {
+  if (!value) {
+    return "--";
+  }
+  const ascii = Array.from(value)
+    .map((byte) => (byte >= 32 && byte <= 126 ? String.fromCharCode(byte) : "."))
+    .join("");
+  return ascii || "--";
 }
 
 function updateTelemetryUI() {
@@ -228,7 +269,27 @@ function parseIndoorBikeData(dataView) {
   updateTelemetryUI();
 }
 
+function parseServicesInput(rawValue) {
+  if (!rawValue) {
+    return [];
+  }
+  return rawValue
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      if (/^[0-9a-fA-F-]{4,}$/.test(entry)) {
+        return entry.toLowerCase();
+      }
+      return entry.toLowerCase().replace(/\s+/g, "_");
+    });
+}
+
 async function connectTrainer() {
+  if (!navigator.bluetooth) {
+    logEvent("Web Bluetooth unavailable in this browser.");
+    return;
+  }
   try {
     trainerDevice = await navigator.bluetooth.requestDevice({
       filters: [{ services: [FTMS_SERVICE] }],
@@ -377,6 +438,10 @@ function stopAutoLoop() {
 }
 
 async function connectZwiftPlay() {
+  if (!navigator.bluetooth) {
+    logEvent("Web Bluetooth unavailable in this browser.");
+    return;
+  }
   try {
     zwiftDevice = await navigator.bluetooth.requestDevice({
       acceptAllDevices: true,
@@ -462,6 +527,264 @@ function parseZwiftNotification(dataView) {
   }
 }
 
+function createDataCard(title) {
+  const card = document.createElement("div");
+  card.className = "data-card";
+  const label = document.createElement("strong");
+  label.textContent = title;
+  const value = document.createElement("span");
+  value.textContent = "--";
+  card.append(label, value);
+  return { card, value };
+}
+
+function updateDeviceButtons(state) {
+  const entries = Array.from(state.buttons.values());
+  entries.sort((a, b) => a.label.localeCompare(b.label));
+  state.buttonsEl.innerHTML = "";
+  if (entries.length === 0) {
+    const pill = document.createElement("div");
+    pill.className = "button-pill";
+    pill.textContent = "No button events yet";
+    state.buttonsEl.appendChild(pill);
+    return;
+  }
+  entries.forEach((entry) => {
+    const pill = document.createElement("div");
+    pill.className = "button-pill";
+    pill.textContent = `${entry.label}: ${entry.count}`;
+    state.buttonsEl.appendChild(pill);
+  });
+}
+
+function registerButtonEvent(state, characteristic, payload) {
+  const label = `${characteristic.uuid.slice(0, 8)} • ${payload}`;
+  const existing = state.buttons.get(label) || { label, count: 0 };
+  existing.count += 1;
+  state.buttons.set(label, existing);
+  updateDeviceButtons(state);
+}
+
+function updateDataCard(state, characteristic, payload) {
+  const key = characteristic.uuid;
+  let cardEntry = state.dataCards.get(key);
+  if (!cardEntry) {
+    cardEntry = createDataCard(`Char ${characteristic.uuid}`);
+    state.dataCards.set(key, cardEntry);
+    state.dataGrid.appendChild(cardEntry.card);
+  }
+  cardEntry.value.textContent = payload;
+}
+
+async function attachCharacteristic(state, characteristic) {
+  const properties = [];
+  if (characteristic.properties.read) {
+    properties.push("read");
+  }
+  if (characteristic.properties.notify) {
+    properties.push("notify");
+  }
+  if (characteristic.properties.indicate) {
+    properties.push("indicate");
+  }
+
+  if (characteristic.properties.read) {
+    try {
+      const value = await characteristic.readValue();
+      const bytes = new Uint8Array(value.buffer);
+      updateDataCard(state, characteristic, formatBytes(bytes));
+    } catch (error) {
+      updateDataCard(state, characteristic, `Read error: ${error.message}`);
+    }
+  }
+
+  if (characteristic.properties.notify || characteristic.properties.indicate) {
+    try {
+      await characteristic.startNotifications();
+      characteristic.addEventListener("characteristicvaluechanged", (event) => {
+        const value = new Uint8Array(event.target.value.buffer);
+        const hex = formatBytes(value);
+        const ascii = formatAscii(value);
+        const combined = `${hex} | ${ascii}`;
+        updateDataCard(state, characteristic, combined);
+        registerButtonEvent(state, characteristic, hex);
+      });
+      state.activeNotifications.push(characteristic);
+    } catch (error) {
+      updateDataCard(state, characteristic, `Notify error: ${error.message}`);
+    }
+  }
+}
+
+async function discoverDeviceDetails(state) {
+  state.status.textContent = "Discovering services...";
+  const services = await state.server.getPrimaryServices();
+  for (const service of services) {
+    const characteristics = await service.getCharacteristics();
+    for (const characteristic of characteristics) {
+      await attachCharacteristic(state, characteristic);
+    }
+  }
+  state.status.textContent = "Listening";
+}
+
+function createDiagnosticsCard(state) {
+  const card = document.createElement("div");
+  card.className = "diagnostic-card";
+
+  const header = document.createElement("div");
+  header.className = "diagnostic-header";
+
+  const title = document.createElement("strong");
+  title.textContent = state.device.name || "Unknown device";
+
+  const status = document.createElement("span");
+  status.className = "status";
+  status.textContent = "Connected";
+
+  const meta = document.createElement("div");
+  meta.className = "diagnostic-meta";
+  const idLine = document.createElement("div");
+  idLine.textContent = `ID: ${state.device.id}`;
+  const servicesLine = document.createElement("div");
+  servicesLine.textContent = `Services: ${state.requestedServices.length || "All"}`;
+  meta.append(idLine, servicesLine);
+
+  header.append(title, status);
+
+  const actions = document.createElement("div");
+  actions.className = "diagnostic-actions";
+  const refreshBtn = document.createElement("button");
+  refreshBtn.textContent = "Refresh data";
+  const rereadBtn = document.createElement("button");
+  rereadBtn.textContent = "Re-read characteristics";
+  rereadBtn.className = "secondary";
+  const disconnectBtn = document.createElement("button");
+  disconnectBtn.textContent = "Disconnect";
+  disconnectBtn.className = "warn";
+  actions.append(refreshBtn, rereadBtn, disconnectBtn);
+
+  const buttonSection = document.createElement("div");
+  const buttonTitle = document.createElement("strong");
+  buttonTitle.textContent = "Button/notify activity";
+  const buttonsEl = document.createElement("div");
+  buttonsEl.className = "button-grid";
+  buttonSection.append(buttonTitle, buttonsEl);
+
+  const dataSection = document.createElement("div");
+  const dataTitle = document.createElement("strong");
+  dataTitle.textContent = "Characteristic data";
+  const dataGrid = document.createElement("div");
+  dataGrid.className = "data-grid";
+  dataSection.append(dataTitle, dataGrid);
+
+  card.append(header, meta, actions, buttonSection, dataSection);
+
+  refreshBtn.addEventListener("click", () => {
+    state.dataCards.forEach((entry) => {
+      entry.value.textContent = "--";
+    });
+  });
+
+  rereadBtn.addEventListener("click", async () => {
+    state.dataCards.forEach((entry) => {
+      entry.value.textContent = "Refreshing...";
+    });
+    state.buttons.clear();
+    updateDeviceButtons(state);
+    await discoverDeviceDetails(state);
+  });
+
+  disconnectBtn.addEventListener("click", () => {
+    if (state.device?.gatt?.connected) {
+      state.device.gatt.disconnect();
+    }
+  });
+
+  state.status = status;
+  state.buttonsEl = buttonsEl;
+  state.dataGrid = dataGrid;
+  state.card = card;
+  state.meta = meta;
+  state.refreshBtn = refreshBtn;
+  state.disconnectBtn = disconnectBtn;
+  state.rereadBtn = rereadBtn;
+  updateDeviceButtons(state);
+
+  return card;
+}
+
+async function connectDiagnosticDevice() {
+  if (!navigator.bluetooth) {
+    logEvent("Web Bluetooth unavailable in this browser.");
+    return;
+  }
+  let device;
+  const requestedServices = parseServicesInput(diagnosticServicesInput.value);
+  const options = { acceptAllDevices: true };
+  if (requestedServices.length) {
+    options.optionalServices = requestedServices;
+  }
+
+  try {
+    device = await navigator.bluetooth.requestDevice(options);
+  } catch (error) {
+    logEvent(`Diagnostic selection cancelled: ${error.message}`);
+    return;
+  }
+
+  if (!device) {
+    return;
+  }
+
+  const server = await device.gatt.connect();
+  const state = {
+    device,
+    server,
+    requestedServices,
+    dataCards: new Map(),
+    buttons: new Map(),
+    activeNotifications: [],
+    status: null,
+    buttonsEl: null,
+    dataGrid: null,
+    card: null,
+    meta: null,
+    refreshBtn: null,
+    disconnectBtn: null,
+    rereadBtn: null,
+  };
+
+  diagnostics.set(device.id, state);
+  const card = createDiagnosticsCard(state);
+  diagnosticDevicesEl.prepend(card);
+  disconnectDiagnosticBtn.disabled = false;
+
+  device.addEventListener("gattserverdisconnected", () => {
+    state.status.textContent = "Disconnected";
+    state.status.dataset.connected = "false";
+    logEvent(`Diagnostic device disconnected: ${device.name || device.id}`);
+    diagnostics.delete(device.id);
+    if (diagnostics.size === 0) {
+      disconnectDiagnosticBtn.disabled = true;
+    }
+  });
+
+  logEvent(`Diagnostic connected: ${device.name || "Unknown"}`);
+  await discoverDeviceDetails(state);
+}
+
+async function disconnectAllDiagnostics() {
+  diagnostics.forEach((state) => {
+    if (state.device?.gatt?.connected) {
+      state.device.gatt.disconnect();
+    }
+  });
+  diagnostics.clear();
+  diagnosticDevicesEl.innerHTML = "";
+  disconnectDiagnosticBtn.disabled = true;
+}
+
 async function disconnectZwiftPlay() {
   if (zwiftDevice?.gatt?.connected) {
     zwiftDevice.gatt.disconnect();
@@ -487,6 +810,9 @@ autoResistanceToggle.addEventListener("change", () => {
 });
 
 reloadRouteBtn.addEventListener("click", loadRoute);
+connectDiagnosticBtn.addEventListener("click", connectDiagnosticDevice);
+disconnectDiagnosticBtn.addEventListener("click", disconnectAllDiagnostics);
 
 loadRoute();
 updateTelemetryUI();
+setBluetoothSupportStatus();

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
     <main class="grid">
       <section class="card" aria-labelledby="connection-heading">
         <h2 id="connection-heading">Connections</h2>
+        <p id="bluetooth-support" class="helper" data-support="checking">
+          Checking Web Bluetooth support…
+        </p>
         <div class="button-row">
           <button id="connect-trainer">Connect Trainer</button>
           <button id="disconnect-trainer" disabled>Disconnect</button>
@@ -115,6 +118,26 @@
           </div>
         </div>
         <div class="event-log" id="event-log"></div>
+      </section>
+
+      <section class="card" aria-labelledby="diagnostics-heading">
+        <h2 id="diagnostics-heading">Bluetooth Diagnostics</h2>
+        <p class="helper">
+          Connect multiple devices, stream button presses, and read raw characteristic data.
+        </p>
+        <div class="control-row">
+          <label for="diagnostic-services">Optional service UUIDs</label>
+          <input
+            id="diagnostic-services"
+            type="text"
+            placeholder="fitness_machine, 0000180f-0000-1000-8000-00805f9b34fb"
+          />
+        </div>
+        <div class="button-row">
+          <button id="connect-diagnostic">Scan &amp; connect device</button>
+          <button id="disconnect-diagnostic" disabled>Disconnect all</button>
+        </div>
+        <div id="diagnostic-devices" class="diagnostic-devices"></div>
       </section>
     </main>
 

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,14 @@ button:disabled {
   gap: 0.75rem;
 }
 
+.control-row input[type="text"] {
+  min-width: 260px;
+  flex: 1;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+}
+
 .control-row input[type="number"] {
   width: 80px;
   padding: 0.3rem 0.5rem;
@@ -139,9 +147,114 @@ button:disabled {
   overflow-y: auto;
 }
 
+.helper {
+  margin: 0;
+  color: #52607a;
+  font-size: 0.9rem;
+}
+
+.helper[data-support="unsupported"] {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.helper[data-support="supported"] {
+  color: #0f766e;
+  font-weight: 600;
+}
+
 .gear-row {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.diagnostic-devices {
+  display: grid;
+  gap: 1rem;
+}
+
+.diagnostic-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.75rem;
+  background: #f8fafc;
+}
+
+.diagnostic-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.diagnostic-meta {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #3b455c;
+}
+
+.diagnostic-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.diagnostic-actions button {
+  background: #0ea5e9;
+}
+
+.diagnostic-actions button.secondary {
+  background: #475569;
+}
+
+.diagnostic-actions button.warn {
+  background: #dc2626;
+}
+
+.data-grid {
+  display: grid;
+  gap: 0.5rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.data-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.data-card strong {
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.data-card span {
+  font-family: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8rem;
+  word-break: break-word;
+}
+
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.button-pill {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
+  text-align: center;
 }


### PR DESCRIPTION
### Motivation
- Browsers that lack Web Bluetooth (notably iOS Safari/Chrome) never prompt for device discovery and produce confusing failures when users try to connect devices. 
- Surface a clear, visible message about API availability and avoid attempting Bluetooth operations in unsupported environments.

### Description
- Add a support helper element `#bluetooth-support` to the Connections panel in `index.html` and a diagnostics panel for multi-device inspection. 
- Implement `setBluetoothSupportStatus()` in `app.js` and call it on load to set `data-support` and helper text, and add early-return guards in `connectTrainer`, `connectZwiftPlay`, and `connectDiagnosticDevice` when `navigator.bluetooth` is missing. 
- Style the supported/unsupported helper states in `styles.css` via `.helper[data-support=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965608b898c8324b3f1ab2847f4d996)